### PR TITLE
[WQ-31] refactor: 배포 후 발생한 이슈 수정 및 리팩토링 

### DIFF
--- a/src/auth/RealHttpClient.ts
+++ b/src/auth/RealHttpClient.ts
@@ -103,8 +103,8 @@ export class RealHttpClient implements HttpClient {
       
       
 
-      // 로그인 응답의 Authorization 헤더에서 토큰 추출 (이메일, Google, Kakao, Naver 공통)
-      if ((url.includes('/auth/email/login') || url.includes('/auth/members/email-login') || url.includes('/auth/google/login') || url.includes('/auth/kakao/login') || url.includes('/auth/naver/login')) && response.ok && authHeaderValue) {
+      // 로그인 및 토큰 갱신 응답의 Authorization 헤더에서 토큰 추출
+      if ((url.includes('/auth/email/login') || url.includes('/auth/members/email-login') || url.includes('/auth/google/login') || url.includes('/auth/kakao/login') || url.includes('/auth/naver/login') || url.includes('/auth/members/refresh')) && response.ok && authHeaderValue) {
         // Authorization 헤더에서 Bearer 토큰 추출
         const authHeader = authHeaderValue;
         if (authHeader.startsWith('Bearer ')) {
@@ -123,7 +123,7 @@ export class RealHttpClient implements HttpClient {
             });
             
             // 토큰 저장 후 사용자 정보 가져오기
-            await this.fetchUserInfo(accessToken);
+            await this.fetchUserInfo();
           } catch (tokenError) {
             console.error('❌ 토큰 저장 실패:', tokenError);
           }
@@ -156,33 +156,12 @@ export class RealHttpClient implements HttpClient {
   }
 
   /**
-   * 사용자 정보 가져오기
+   * 사용자 정보 가져오기 (중복 호출 방지를 위해 비활성화)
+   * Dashboard 컴포넌트에서만 user-info API를 호출하도록 함
    */
-  private async fetchUserInfo(accessToken: string): Promise<void> {
-    try {
-      const userInfoResponse = await fetch('/api/v1/auth/members/user-info', {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer ${accessToken}`,
-          'Accept': 'application/json',
-          'X-Client-Type': 'web'
-        },
-        credentials: 'include'
-      });
-
-      if (userInfoResponse.ok) {
-        const userInfo = await userInfoResponse.json();
-        
-        // 사용자 정보를 localStorage에 저장 (data 부분만 저장)
-        if (userInfo.success && userInfo.data) {
-          localStorage.setItem('user_info', JSON.stringify(userInfo.data));
-        } else {
-          localStorage.setItem('user_info', JSON.stringify(userInfo));
-        }
-      }
-    } catch (error) {
-      console.error('❌ 사용자 정보 가져오기 중 오류:', error);
-    }
+  private async fetchUserInfo(): Promise<void> {
+    // 중복 API 호출 방지를 위해 비활성화
+    // Dashboard 컴포넌트에서 이미 user-info API를 호출하므로 여기서는 호출하지 않음
   }
 
   /**

--- a/src/auth/TokenRefreshService.ts
+++ b/src/auth/TokenRefreshService.ts
@@ -156,6 +156,7 @@ export class TokenRefreshService {
       
       // 웹에서는 refreshToken을 쿠키로 관리하므로 현재 provider 타입으로 갱신
       const currentProvider = getCurrentProviderType();
+      
       const refreshResult = await authManager.refreshToken({ 
         provider: currentProvider
       });

--- a/src/components/oauth/GoogleCallback.tsx
+++ b/src/components/oauth/GoogleCallback.tsx
@@ -75,10 +75,25 @@ const GoogleCallback = () => {
         }
         
         if (oauthInProgress === 'true' && oauthProvider === 'google') {
+          // 인가 코드 재사용 방지: 이미 처리된 코드인지 확인
+          const existingCode = localStorage.getItem('google_auth_code');
+          if (existingCode === code) {
+            console.warn('⚠️ 이미 처리된 인가 코드입니다. 중복 처리 방지');
+            localStorage.removeItem('oauth_in_progress');
+            localStorage.removeItem('oauth_provider');
+            setTimeout(() => {
+              window.location.href = '/';
+            }, 1000);
+            return;
+          }
+          
           // localStorage에 인증 코드 저장하고 메인 페이지로 리다이렉트
           localStorage.setItem('google_auth_code', code);
           localStorage.removeItem('oauth_in_progress');
           localStorage.removeItem('oauth_provider');
+          
+          // 인가 코드 사용 플래그 설정 (재사용 방지)
+          localStorage.setItem('google_code_used', 'false');
           
           setTimeout(() => {
             window.location.href = '/';

--- a/src/config/auth.config.ts
+++ b/src/config/auth.config.ts
@@ -19,21 +19,21 @@ const API_CONFIGS = {
 
       // Google OAuth 엔드포인트
       googleLogin: '/api/v1/auth/google/login',
-      googleLogout: '/api/v1/auth/google/logout', //소셜 로그아웃 통일 (클라에서 토큰 삭제)
+      googleLogout: '/api/v1/auth/members/logout', //소셜 로그아웃 통일 (API 호출 방식)
       googleRefresh: '/api/v1/auth/members/refresh', //토큰 갱신 통일 (소셜+이메일)
       googleValidate: '/api/v1/auth/google/validate',
       googleUserinfo: '/api/v1/auth/members/user-info', //유저 정보 조회 통일 (소셜+이메일)
 
       // Kakao OAuth 엔드포인트
       kakaoLogin: '/api/v1/auth/kakao/login',
-      kakaoLogout: '/api/v1/auth/kakao/logout',
+      kakaoLogout: '/api/v1/auth/members/logout', //소셜 로그아웃 통일 (API 호출 방식)
       kakaoRefresh: '/api/v1/auth/members/refresh',
       kakaoValidate: '/api/v1/auth/kakao/validate',
       kakaoUserinfo: '/api/v1/auth/members/user-info',
 
       // Naver OAuth 엔드포인트
       naverLogin: '/api/v1/auth/naver/login',
-      naverLogout: '/api/v1/auth/naver/logout',
+      naverLogout: '/api/v1/auth/members/logout', //소셜 로그아웃 통일 (API 호출 방식)
       naverRefresh: '/api/v1/auth/members/refresh',
       naverValidate: '/api/v1/auth/naver/validate',
       naverUserinfo: '/api/v1/auth/members/user-info'
@@ -56,21 +56,21 @@ const API_CONFIGS = {
 
       // Google OAuth 엔드포인트
       googleLogin: '/api/v1/auth/google/login',
-      googleLogout: '/api/v1/auth/google/logout',
+      googleLogout: '/api/v1/auth/members/logout', //소셜 로그아웃 통일 (API 호출 방식)
       googleRefresh: '/api/v1/auth/members/refresh',
       googleValidate: '/api/v1/auth/google/validate',
       googleUserinfo: '/api/v1/auth/members/user-info',
 
       // Kakao OAuth 엔드포인트
       kakaoLogin: '/api/v1/auth/kakao/login',
-      kakaoLogout: '/api/v1/auth/kakao/logout',
+      kakaoLogout: '/api/v1/auth/members/logout', //소셜 로그아웃 통일 (API 호출 방식)
       kakaoRefresh: '/api/v1/auth/members/refresh',
       kakaoValidate: '/api/v1/auth/kakao/validate',
       kakaoUserinfo: '/api/v1/auth/members/user-info',
 
       // Naver OAuth 엔드포인트
       naverLogin: '/api/v1/auth/naver/login',
-      naverLogout: '/api/v1/auth/naver/logout',
+      naverLogout: '/api/v1/auth/members/logout', //소셜 로그아웃 통일 (API 호출 방식)
       naverRefresh: '/api/v1/auth/members/refresh',
       naverValidate: '/api/v1/auth/naver/validate',
       naverUserinfo: '/api/v1/auth/members/user-info'


### PR DESCRIPTION
1. user-info API 중복 요청 문제 (304 에러)
- 문제: 로그인 성공 후 user-info API가 두 번 호출되어 첫 번째는 304 에러, 두 번째는 200 응답
- 원인: Dashboard.tsx, App.tsx, RealHttpClient.ts에서 동시에 API 호출
- 해결: Dashboard.tsx에서만 API 호출하도록 중앙화, localStorage 캐시 우선 사용으로 불필요한 API 호출 방지
2. 토큰 갱신 후 UI 업데이트 문제
- 문제: 토큰 즉시 갱신 후 화면의 남은 시간이 즉시 업데이트되지 않음
- 해결: JWT에서 직접 남은 시간 계산하여 즉시 업데이트, 토큰 갱신 후 재시도 로직 추가, /auth/members/refresh 응답에서도 Authorization 헤더 처리, 새로운 access token을 WebTokenStore에 저장
3. 구글 OAuth 400 에러 (인가 코드 재사용)
- 문제: "유효하지 않은 Google 인가 코드입니다" 에러
- 해결:인가 코드 중복 처리 방지 로직 추가, 인가 코드 사용 플래그로 재사용 방지
4. 로그아웃 로직 통일
- 모든 로그인 방식이 동일한 로그아웃 API 호출 방식으로 통일