### PR TITLE
[WQ-182] refactor: Zustand를 사용하여 인증 상태 전역으로 관리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "jwt-decode": "^4.0.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
-        "react-router-dom": "^7.8.2"
+        "react-router-dom": "^7.8.2",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1438,7 +1439,7 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2157,7 +2158,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -4533,6 +4534,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "jwt-decode": "^4.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.8.2"
+    "react-router-dom": "^7.8.2",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,8 +154,6 @@ function AppContent() {
   };
 
   const handleLoginSuccess = async () => {
-    // 로그인 성공, 인증 상태 업데이트
-    await refreshAuthStatus();
     // 로그인 성공 시 토큰 갱신 서비스 시작
     initializeTokenRefreshService();
     
@@ -165,12 +163,10 @@ function AppContent() {
       await fetchUserInfoAfterEmailLogin();
     }
     
-    navigate('/login/complete');
+    // Zustand 스토어 상태 업데이트 (전역 상태 즉시 반영)
+    await refreshAuthStatus();
     
-    // 잠시 후 토큰 상태를 확인하여 UI 업데이트
-    setTimeout(async () => {
-      await refreshAuthStatus();
-    }, 500);
+    navigate('/login/complete');
   };
 
   const handleLogout = async () => {
@@ -189,6 +185,7 @@ function AppContent() {
       }
       
       if (result.success) {
+        // Zustand 스토어 상태 업데이트 (전역 상태 즉시 반영)
         await refreshAuthStatus();
         setShowSplash(true);
         alert('✅ 로그아웃되었습니다.');

--- a/src/auth/RealHttpClient.ts
+++ b/src/auth/RealHttpClient.ts
@@ -1,6 +1,7 @@
 import type { HttpClient, HttpRequestConfig, HttpResponse } from 'growgrammers-auth-core';
 import { getTokenRefreshService } from './TokenRefreshService';
 import { getExpirationFromJWT } from '../utils/jwtUtils';
+import { useAuthStore } from '../stores/authStore';
 
 // Helpers
 function isFormData(v: unknown): v is FormData {
@@ -134,6 +135,9 @@ export class RealHttpClient implements HttpClient {
               accessToken: accessToken,
               expiredAt: expiredAt
             });
+            
+            // Zustand 스토어 상태 업데이트 (로그인 성공)
+            useAuthStore.getState().login();
             
             // 토큰 저장 후 사용자 정보 가져오기
             await this.fetchUserInfo();

--- a/src/auth/TokenRefreshService.ts
+++ b/src/auth/TokenRefreshService.ts
@@ -162,6 +162,12 @@ export class TokenRefreshService {
       });
 
       if (refreshResult.success) {
+        // 토큰 갱신 성공 시 authStore의 토큰 만료 시간 업데이트
+        // authStore를 동적으로 import하여 순환 참조 방지
+        const { useAuthStore } = await import('../stores/authStore');
+        await useAuthStore.getState().updateTimeUntilExpiry();
+        
+        //console.log('[TokenRefreshService] 토큰 갱신 성공 및 만료 시간 업데이트 완료');
         return true;
       } else {
         console.error('[TokenRefreshService] 토큰 갱신 실패:', refreshResult.error);

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -53,26 +53,21 @@ const Dashboard = ({ onLogout }: DashboardProps) => {
         setTokenInfo(null);
       }
 
-      // 사용자 정보 가져오기 (localStorage에서 먼저 확인)
+      // 사용자 정보 가져오기 (캐시된 데이터 먼저 확인)
       try {
-        // localStorage에서 사용자 정보 확인
-        const storedUserInfo = localStorage.getItem('user_info');
-        if (storedUserInfo) {
-          const parsedUserInfo = JSON.parse(storedUserInfo);
-          // Zustand 스토어에만 저장
-          useAuthStore.getState().setAuthStatus({ userInfo: parsedUserInfo });
+        // 일원화된 메서드로 캐시된 데이터 확인 (localStorage 접근 일원화)
+        const cachedUserInfo = useAuthStore.getState().loadUserInfoFromStorage();
+        if (cachedUserInfo) {
           // 캐시된 데이터가 있으면 API 호출하지 않음 (중복 요청 방지)
           return;
         }
         
-        // localStorage에 없을 때만 API 호출 (한 번만)
+        // 캐시에 없을 때만 API 호출 (한 번만)
         const userResult = await authManager.getCurrentUserInfo();
         
         if (userResult.success && userResult.data) {
-          // localStorage에 저장
-          localStorage.setItem('user_info', JSON.stringify(userResult.data));
-          // Zustand 스토어에만 저장 (SSOT)
-          useAuthStore.getState().setAuthStatus({ userInfo: userResult.data });
+          // 일원화된 메서드로 저장 (localStorage 접근 일원화)
+          useAuthStore.getState().setUserInfo(userResult.data);
         } else {
           // AuthManager 실패 시 쿠키 기반으로 직접 API 호출 (한 번만)
           try {
@@ -90,9 +85,8 @@ const Dashboard = ({ onLogout }: DashboardProps) => {
               
               // data 부분만 사용자 정보로 설정
               const actualUserInfo = userInfoData.success && userInfoData.data ? userInfoData.data : userInfoData;
-              localStorage.setItem('user_info', JSON.stringify(actualUserInfo));
-              // Zustand 스토어에만 저장 (SSOT)
-              useAuthStore.getState().setAuthStatus({ userInfo: actualUserInfo });
+              // 일원화된 메서드로 저장 (localStorage 접근 일원화)
+              useAuthStore.getState().setUserInfo(actualUserInfo);
             } else {
               throw new Error(`HTTP ${userInfoResponse.status}`);
             }
@@ -108,9 +102,8 @@ const Dashboard = ({ onLogout }: DashboardProps) => {
                        currentProvider === 'kakao' ? 'Kakao 데모 사용자' : '이메일 데모 사용자',
               provider: getCurrentProviderType()
             };
-            localStorage.setItem('user_info', JSON.stringify(dummyUserInfo));
-            // Zustand 스토어에만 저장 (SSOT)
-            useAuthStore.getState().setAuthStatus({ userInfo: dummyUserInfo });
+            // 일원화된 메서드로 저장 (localStorage 접근 일원화)
+            useAuthStore.getState().setUserInfo(dummyUserInfo);
           }
         }
       } catch (userError) {
@@ -125,9 +118,8 @@ const Dashboard = ({ onLogout }: DashboardProps) => {
                    currentProvider === 'kakao' ? 'Kakao 데모 사용자' : '이메일 데모 사용자',
           provider: getCurrentProviderType()
         };
-        localStorage.setItem('user_info', JSON.stringify(dummyUserInfo));
-        // Zustand 스토어에만 저장 (SSOT)
-        useAuthStore.getState().setAuthStatus({ userInfo: dummyUserInfo });
+        // 일원화된 메서드로 저장 (localStorage 접근 일원화)
+        useAuthStore.getState().setUserInfo(dummyUserInfo);
       }
     } catch (error) {
       console.error('❌ 사용자 데이터 로드 실패:', error);

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { getAuthManager, getCurrentProviderType } from '../../auth/authManager';
 import { getTokenRefreshService } from '../../auth/TokenRefreshService';
-import { isJWTExpired, getExpirationFromJWT } from '../../utils/jwtUtils';
+import { isJWTExpired } from '../../utils/jwtUtils';
 import { useAuthStatus } from '../../hooks';
 import { useAuthStore } from '../../stores/authStore';
 import { BUTTON_STYLES, CARD_STYLES, LOADING_STYLES } from '../../styles';
@@ -20,7 +20,7 @@ interface TokenInfo {
 }
 
 const Dashboard = ({ onLogout }: DashboardProps) => {
-  const { isAuthenticated, timeUntilExpiry, userInfo } = useAuthStatus();
+  const { isAuthenticated, timeUntilExpiry, tokenExpiredAt, userInfo } = useAuthStatus();
   const [tokenInfo, setTokenInfo] = useState<TokenInfo | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -293,16 +293,12 @@ const Dashboard = ({ onLogout }: DashboardProps) => {
                   🍪 HttpOnly 쿠키 (JS 접근 불가, 네트워크 탭에서 확인됨)
                 </span>
               </p>
-              {tokenInfo.accessToken && (() => {
-                // JWT에서 만료 시간 추출 (기존 로직과 동일)
-                const expiredAt = getExpirationFromJWT(tokenInfo.accessToken);
-                return expiredAt ? (
-                  <p className="my-3 text-sm flex justify-between items-center">
-                    <strong className="text-gray-900 font-semibold min-w-[80px]">만료 시간:</strong> 
-                    {new Date(expiredAt).toLocaleString()}
-                  </p>
-                ) : null;
-              })()}
+              {tokenExpiredAt && (
+                <p className="my-3 text-sm flex justify-between items-center">
+                  <strong className="text-gray-900 font-semibold min-w-[80px]">만료 시간:</strong> 
+                  {new Date(tokenExpiredAt).toLocaleString()}
+                </p>
+              )}
               {timeUntilExpiry !== null && (
                 <p className="my-3 text-sm flex justify-between items-center">
                   <strong className="text-gray-900 font-semibold min-w-[80px]">남은 시간:</strong> 

--- a/src/hooks/useAuthStatus.ts
+++ b/src/hooks/useAuthStatus.ts
@@ -4,6 +4,7 @@ interface UseAuthStatusReturn {
   isAuthenticated: boolean;
   isLoading: boolean;
   timeUntilExpiry: number | null;
+  tokenExpiredAt: number | null;
   userInfo: UserInfo | null;
   refreshAuthStatus: () => Promise<void>;
   login: (userInfo?: UserInfo) => void;
@@ -19,6 +20,7 @@ export const useAuthStatus = (): UseAuthStatusReturn => {
     isAuthenticated,
     isLoading,
     timeUntilExpiry,
+    tokenExpiredAt,
     userInfo,
     refreshAuthStatus,
     login,
@@ -29,6 +31,7 @@ export const useAuthStatus = (): UseAuthStatusReturn => {
     isAuthenticated,
     isLoading,
     timeUntilExpiry,
+    tokenExpiredAt,
     userInfo,
     refreshAuthStatus,
     login,

--- a/src/hooks/useAuthStatus.ts
+++ b/src/hooks/useAuthStatus.ts
@@ -1,81 +1,37 @@
-import { useState, useEffect } from 'react';
-import { checkAuthStatus, getAuthManager } from '../auth/authManager';
-import { getTokenRefreshService } from '../auth/TokenRefreshService';
-import { getTimeUntilExpiryFromJWT } from '../utils/jwtUtils';
+import { useAuthStore, type UserInfo } from '../stores/authStore';
 
 interface UseAuthStatusReturn {
   isAuthenticated: boolean;
   isLoading: boolean;
   timeUntilExpiry: number | null;
+  userInfo: UserInfo | null;
   refreshAuthStatus: () => Promise<void>;
+  login: (userInfo?: UserInfo) => void;
+  logout: () => void;
 }
 
+/**
+ * 인증 상태 관리 훅 (Zustand 기반)
+ * 이제 전역 상태를 사용하므로 모든 컴포넌트가 동일한 상태를 공유합니다.
+ */
 export const useAuthStatus = (): UseAuthStatusReturn => {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [timeUntilExpiry, setTimeUntilExpiry] = useState<number | null>(null);
-
-  const refreshAuthStatus = async () => {
-    try {
-      setIsLoading(true);
-      const authStatus = await checkAuthStatus();
-      setIsAuthenticated(authStatus.isAuthenticated);
-      
-      if (authStatus.isAuthenticated) {
-        // 토큰 만료 시간 추적
-        const authManager = getAuthManager();
-        const tokenResult = await authManager.getToken();
-        
-        if (tokenResult.success && tokenResult.data?.accessToken) {
-          // JWT에서 직접 남은 시간 계산
-          const remainingFromJWT = getTimeUntilExpiryFromJWT(tokenResult.data.accessToken);
-          if (remainingFromJWT !== null) {
-            setTimeUntilExpiry(remainingFromJWT);
-          } else {
-            // JWT 파싱 실패시 폴백
-            const tokenRefreshService = getTokenRefreshService();
-            const remaining = await tokenRefreshService.getTimeUntilExpiry();
-            setTimeUntilExpiry(remaining);
-          }
-        }
-      }
-    } catch (error) {
-      console.error('인증 상태 확인 중 오류:', error);
-      setIsAuthenticated(false);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    refreshAuthStatus();
-    
-    // 토큰 만료 시간 추적 타이머
-    const interval = setInterval(async () => {
-      if (isAuthenticated) {
-        const authManager = getAuthManager();
-        const tokenResult = await authManager.getToken();
-        
-        if (tokenResult.success && tokenResult.data?.accessToken) {
-          const remainingFromJWT = getTimeUntilExpiryFromJWT(tokenResult.data.accessToken);
-          if (remainingFromJWT !== null) {
-            setTimeUntilExpiry(remainingFromJWT);
-          } else {
-            const tokenRefreshService = getTokenRefreshService();
-            const remaining = await tokenRefreshService.getTimeUntilExpiry();
-            setTimeUntilExpiry(remaining);
-          }
-        }
-      }
-    }, 30000); // 30초마다 확인
-    
-    return () => clearInterval(interval);
-  }, [isAuthenticated]);
+  const {
+    isAuthenticated,
+    isLoading,
+    timeUntilExpiry,
+    userInfo,
+    refreshAuthStatus,
+    login,
+    logout
+  } = useAuthStore();
 
   return {
     isAuthenticated,
     isLoading,
     timeUntilExpiry,
-    refreshAuthStatus
+    userInfo,
+    refreshAuthStatus,
+    login,
+    logout
   };
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,10 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
+import { initializeAuthStore } from './stores/authStore'
+
+// 앱 시작 시 인증 상태 초기화
+initializeAuthStore();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,0 +1,186 @@
+import { create } from 'zustand';
+import { checkAuthStatus, getAuthManager } from '../auth/authManager';
+import { getTokenRefreshService } from '../auth/TokenRefreshService';
+import { getTimeUntilExpiryFromJWT } from '../utils/jwtUtils';
+
+/**
+ * 사용자 정보 타입
+ */
+export interface UserInfo {
+  id?: string;
+  email: string;
+  nickname?: string;
+  provider: string;
+}
+
+interface AuthState {
+  // 상태
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  timeUntilExpiry: number | null;
+  userInfo: UserInfo | null;
+
+  // Actions
+  setAuthStatus: (status: Partial<AuthState>) => void;
+  refreshAuthStatus: () => Promise<void>;
+  login: (userInfo?: UserInfo) => void;
+  logout: () => void;
+  updateTimeUntilExpiry: () => Promise<void>;
+  startExpiryTimer: () => void;
+  stopExpiryTimer: () => void;
+}
+
+// 타이머 ID 저장
+let expiryTimerInterval: number | null = null;
+
+export const useAuthStore = create<AuthState>((set, get) => ({
+  // 초기 상태
+  isAuthenticated: false,
+  isLoading: true,
+  timeUntilExpiry: null,
+  userInfo: null,
+
+  // 상태 업데이트
+  setAuthStatus: (status) => set(status),
+
+  // 인증 상태 새로고침
+  refreshAuthStatus: async () => {
+    try {
+      set({ isLoading: true });
+      const authStatus = await checkAuthStatus();
+      set({ isAuthenticated: authStatus.isAuthenticated });
+
+      if (authStatus.isAuthenticated) {
+        // 토큰 만료 시간 추적
+        const authManager = getAuthManager();
+        const tokenResult = await authManager.getToken();
+
+        if (tokenResult.success && tokenResult.data?.accessToken) {
+          // JWT에서 직접 남은 시간 계산
+          const remainingFromJWT = getTimeUntilExpiryFromJWT(tokenResult.data.accessToken);
+          if (remainingFromJWT !== null) {
+            set({ timeUntilExpiry: remainingFromJWT });
+          } else {
+            // JWT 파싱 실패시 폴백
+            const tokenRefreshService = getTokenRefreshService();
+            const remaining = await tokenRefreshService.getTimeUntilExpiry();
+            set({ timeUntilExpiry: remaining });
+          }
+        }
+
+        // 사용자 정보 로드 (localStorage에서)
+        const storedUserInfo = localStorage.getItem('user_info');
+        if (storedUserInfo) {
+          try {
+            const parsedUserInfo = JSON.parse(storedUserInfo);
+            set({ userInfo: parsedUserInfo });
+          } catch (error) {
+            console.error('사용자 정보 파싱 실패:', error);
+          }
+        }
+      } else {
+        // 인증되지 않은 경우 상태 초기화
+        set({ timeUntilExpiry: null, userInfo: null });
+      }
+    } catch (error) {
+      console.error('인증 상태 확인 중 오류:', error);
+      set({ isAuthenticated: false, timeUntilExpiry: null, userInfo: null });
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+
+  // 로그인 처리
+  login: (userInfo) => {
+    set({
+      isAuthenticated: true,
+      isLoading: false,
+      userInfo: userInfo || null
+    });
+
+    // 로그인 후 타이머 시작
+    get().startExpiryTimer();
+  },
+
+  // 로그아웃 처리
+  logout: () => {
+    set({
+      isAuthenticated: false,
+      userInfo: null,
+      timeUntilExpiry: null,
+      isLoading: false
+    });
+
+    // 로그아웃 시 타이머 중지
+    get().stopExpiryTimer();
+
+    // localStorage 정리
+    localStorage.removeItem('user_info');
+  },
+
+  // 토큰 만료 시간 업데이트
+  updateTimeUntilExpiry: async () => {
+    const { isAuthenticated } = get();
+    if (!isAuthenticated) return;
+
+    try {
+      const authManager = getAuthManager();
+      const tokenResult = await authManager.getToken();
+
+      if (tokenResult.success && tokenResult.data?.accessToken) {
+        const remainingFromJWT = getTimeUntilExpiryFromJWT(tokenResult.data.accessToken);
+        if (remainingFromJWT !== null) {
+          set({ timeUntilExpiry: remainingFromJWT });
+        } else {
+          const tokenRefreshService = getTokenRefreshService();
+          const remaining = await tokenRefreshService.getTimeUntilExpiry();
+          set({ timeUntilExpiry: remaining });
+        }
+      }
+    } catch (error) {
+      console.error('토큰 만료 시간 업데이트 중 오류:', error);
+    }
+  },
+
+  // 만료 시간 타이머 시작
+  startExpiryTimer: () => {
+    // 기존 타이머가 있으면 중지
+    if (expiryTimerInterval) {
+      clearInterval(expiryTimerInterval);
+    }
+
+    // 30초마다 토큰 만료 시간 업데이트
+    expiryTimerInterval = window.setInterval(() => {
+      get().updateTimeUntilExpiry();
+    }, 30000);
+
+    // 즉시 한 번 실행
+    get().updateTimeUntilExpiry();
+  },
+
+  // 만료 시간 타이머 중지
+  stopExpiryTimer: () => {
+    if (expiryTimerInterval) {
+      clearInterval(expiryTimerInterval);
+      expiryTimerInterval = null;
+    }
+  }
+}));
+
+// 앱 시작 시 인증 상태 확인
+export const initializeAuthStore = async () => {
+  await useAuthStore.getState().refreshAuthStatus();
+  
+  // 인증된 상태면 타이머 시작
+  if (useAuthStore.getState().isAuthenticated) {
+    useAuthStore.getState().startExpiryTimer();
+  }
+};
+
+// 페이지 언로드 시 타이머 정리
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeunload', () => {
+    useAuthStore.getState().stopExpiryTimer();
+  });
+}
+

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -162,7 +162,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   },
 
-  // 타임스탬프로부터 남은 시간 계산 (1초마다 호출)
+  // 타임스탬프로부터 남은 시간 계산 (30초마다 호출)
   updateTimeUntilExpiryFromTimestamp: () => {
     const { tokenExpiredAt, isAuthenticated } = get();
     if (!isAuthenticated || !tokenExpiredAt) return;
@@ -182,10 +182,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     // 즉시 한 번 실행 (JWT에서 만료 시간 가져오기)
     get().updateTimeUntilExpiry();
 
-    // 1초마다 남은 시간 업데이트 (실시간 카운트다운)
+    // 30초마다 남은 시간 업데이트 (분 단위 표시에 적합한 주기)
     expiryTimerInterval = window.setInterval(() => {
       get().updateTimeUntilExpiryFromTimestamp();
-    }, 1000); // 1초마다 업데이트
+    }, 30_000); // 30초마다 업데이트
   },
 
   // 만료 시간 타이머 중지

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,2 @@
+export { useAuthStore, initializeAuthStore, type UserInfo } from './authStore';
+

--- a/src/utils/logoutUtils.ts
+++ b/src/utils/logoutUtils.ts
@@ -27,10 +27,8 @@ export async function handleOAuthLogout(provider: 'google' | 'naver' | 'kakao', 
       localStorage.removeItem('oauth_provider');
       localStorage.removeItem('current_provider_type');
       
-      // 사용자 정보 정리
-      localStorage.removeItem('user_info');
-      
       // Zustand 스토어 상태 업데이트 (로그아웃)
+      // logout() 내부에서 clearUserInfo()를 호출하여 user_info도 정리됨
       useAuthStore.getState().logout();
     }
     
@@ -58,10 +56,8 @@ export async function handleEmailLogout(authManager: AuthManager, provider: stri
     // 이메일 로그아웃 시에도 provider type 정리
     localStorage.removeItem('current_provider_type');
     
-    // 사용자 정보 정리
-    localStorage.removeItem('user_info');
-    
     // Zustand 스토어 상태 업데이트 (로그아웃)
+    // logout() 내부에서 clearUserInfo()를 호출하여 user_info도 정리됨
     useAuthStore.getState().logout();
   }
   

--- a/src/utils/logoutUtils.ts
+++ b/src/utils/logoutUtils.ts
@@ -3,6 +3,7 @@
  */
 
 import type { AuthManager, AuthProviderType } from 'growgrammers-auth-core';
+import { useAuthStore } from '../stores/authStore';
 
 /**
  * OAuth 제공자별 로그아웃 처리 (구글, 네이버, 카카오)
@@ -28,6 +29,9 @@ export async function handleOAuthLogout(provider: 'google' | 'naver' | 'kakao', 
       
       // 사용자 정보 정리
       localStorage.removeItem('user_info');
+      
+      // Zustand 스토어 상태 업데이트 (로그아웃)
+      useAuthStore.getState().logout();
     }
     
     return result;
@@ -56,6 +60,9 @@ export async function handleEmailLogout(authManager: AuthManager, provider: stri
     
     // 사용자 정보 정리
     localStorage.removeItem('user_info');
+    
+    // Zustand 스토어 상태 업데이트 (로그아웃)
+    useAuthStore.getState().logout();
   }
   
   return result;


### PR DESCRIPTION
close [WQ-182]

연동 페이지를 추가하게 되면 3개 이상의 컴포넌트에서 각각 독립적으로 인증 상태를 가져와서 사용하기 때문에 동기화 지연, 메모리 낭비 문제가 생깁니다. 
이를 방지하기 위해 Zustand를 사용한 인증 상태 관리 리팩토링하였습니다.

### 주요 변경 사항
1. Zustand (전역 상태 라이브러리) 도입 (src/stores/authStore.ts)
- 전역 인증 상태 관리 스토어 생성
- isAuthenticated, isLoading, timeUntilExpiry, userInfo 상태 관리
- login(), logout(), refreshAuthStatus() 액션 
- 30초마다 저장된 타임스탬프로부터 남은 시간 실시간 계산
- localStorage 접근을 authStore의 3개 메서드(setUserInfo, loadUserInfoFromStorage, clearUserInfo)로 캡슐화하여 PII 저장/로드/삭제 경로를 중앙 관리

2. 컴포넌트 업데이트 (즉시 상태 동기화)
- App.tsx: 로그인/로그아웃 시 Zustand 스토어 즉시 업데이트
- Dashboard.tsx: Zustand 스토어에서 userInfo 직접 가져오기
- RealHttpClient.ts: 로그인 성공 시 login() 호출
- logoutUtils.ts: 로그아웃 시 logout() 호출

[WQ-182]: https://growgrammers.atlassian.net/browse/WQ-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ